### PR TITLE
Add a helper method for making up name

### DIFF
--- a/headers.go
+++ b/headers.go
@@ -74,3 +74,12 @@ func InvalidResponseFormat(value string, allowed []string) *Validation {
 		message: fmt.Sprintf(responseFormatFail, allowed),
 	}
 }
+
+// Validate error message name for aliased property
+func (e *Validation) ValidateName(name string) *Validation {
+	if e.Name == "" && name != "" {
+		e.Name = name
+		e.message = name+e.message
+	}
+	return e
+}


### PR DESCRIPTION
The method is used to make up name information when a validation error occurs, so the error message can contain proper name which helps identify what property failed the validation. This is especially useful for the use case of aliased property validation.