### PR TITLE
Set Content-Type explicitly in ServeError

### DIFF
--- a/api.go
+++ b/api.go
@@ -113,6 +113,7 @@ func MethodNotAllowed(requested string, allow []string) Error {
 
 // ServeError the error handler interface implemenation
 func ServeError(rw http.ResponseWriter, r *http.Request, err error) {
+	rw.Header().Set("Content-Type", "application/json")
 	switch e := err.(type) {
 	case *CompositeError:
 		er := flattenComposite(e)


### PR DESCRIPTION
I have a swagger specification that produces either `application/json` or `image/jpeg`. When I receive errors generated by swagger (such as "path not found" or "method not allowed") it will default to using `image/jpeg`, even though the content can only ever be json.
Adding this line makes sure that the content type header matches the actual content.

_(sorry if this isn't completely in line with your contribution guidelines, but I felt the overhead for a single line change was somewhat big)_