### PR TITLE
Default error code can be changed externally

### DIFF
--- a/api.go
+++ b/api.go
@@ -21,6 +21,9 @@ import (
 	"strings"
 )
 
+// DefaultHTTPCode is used when the error Code cannot be used as an HTTP code.
+var DefaultHTTPCode = 422
+
 // Error represents a error interface all swagger framework errors implement
 type Error interface {
 	error
@@ -155,7 +158,7 @@ func ServeError(rw http.ResponseWriter, r *http.Request, err error) {
 
 func asHTTPCode(input int) int {
 	if input >= 600 {
-		return 422
+		return DefaultHTTPCode
 	}
 	return input
 }

--- a/api_test.go
+++ b/api_test.go
@@ -50,6 +50,20 @@ func TestServeError(t *testing.T) {
 	// assert.Equal(t, "application/json", recorder.Header().Get("content-type"))
 	assert.Equal(t, `{"code":601,"message":"someType is an invalid type name"}`, recorder.Body.String())
 
+	// same, but override DefaultHTTPCode
+	func() {
+		oldDefaultHTTPCode := DefaultHTTPCode
+		defer func() { DefaultHTTPCode = oldDefaultHTTPCode }()
+		DefaultHTTPCode = http.StatusBadRequest
+
+		err = InvalidTypeName("someType")
+		recorder = httptest.NewRecorder()
+		ServeError(recorder, nil, err)
+		assert.Equal(t, http.StatusBadRequest, recorder.Code)
+		// assert.Equal(t, "application/json", recorder.Header().Get("content-type"))
+		assert.Equal(t, `{"code":601,"message":"someType is an invalid type name"}`, recorder.Body.String())
+	}()
+
 	// defaults to internal server error
 	simpleErr := fmt.Errorf("some error")
 	recorder = httptest.NewRecorder()


### PR DESCRIPTION
When the error Code cannot be used as an HTTP code, use a variable
instead of 422 fixed code so the user can set it accordingly to its
API policy.
