### PR TITLE
Use constants from net/http pkg instead of self consts and raw numbers

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,3 +17,4 @@ linters:
   disable:
     - maligned
     - lll
+    - gochecknoglobals

--- a/api.go
+++ b/api.go
@@ -23,7 +23,7 @@ import (
 )
 
 // DefaultHTTPCode is used when the error Code cannot be used as an HTTP code.
-var DefaultHTTPCode = 422
+var DefaultHTTPCode = http.StatusUnprocessableEntity
 
 // Error represents a error interface all swagger framework errors implement
 type Error interface {
@@ -115,8 +115,6 @@ func MethodNotAllowed(requested string, allow []string) Error {
 	return &MethodNotAllowedError{code: http.StatusMethodNotAllowed, Allowed: allow, message: msg}
 }
 
-const head = "HEAD"
-
 // ServeError the error handler interface implementation
 func ServeError(rw http.ResponseWriter, r *http.Request, err error) {
 	rw.Header().Set("Content-Type", "application/json")
@@ -133,7 +131,7 @@ func ServeError(rw http.ResponseWriter, r *http.Request, err error) {
 	case *MethodNotAllowedError:
 		rw.Header().Add("Allow", strings.Join(err.(*MethodNotAllowedError).Allowed, ","))
 		rw.WriteHeader(asHTTPCode(int(e.Code())))
-		if r == nil || r.Method != head {
+		if r == nil || r.Method != http.MethodHead {
 			_, _ = rw.Write(errorAsJSON(e))
 		}
 	case Error:
@@ -144,7 +142,7 @@ func ServeError(rw http.ResponseWriter, r *http.Request, err error) {
 			return
 		}
 		rw.WriteHeader(asHTTPCode(int(e.Code())))
-		if r == nil || r.Method != head {
+		if r == nil || r.Method != http.MethodHead {
 			_, _ = rw.Write(errorAsJSON(e))
 		}
 	case nil:
@@ -152,7 +150,7 @@ func ServeError(rw http.ResponseWriter, r *http.Request, err error) {
 		_, _ = rw.Write(errorAsJSON(New(http.StatusInternalServerError, "Unknown error")))
 	default:
 		rw.WriteHeader(http.StatusInternalServerError)
-		if r == nil || r.Method != head {
+		if r == nil || r.Method != http.MethodHead {
 			_, _ = rw.Write(errorAsJSON(New(http.StatusInternalServerError, err.Error())))
 		}
 	}

--- a/auth.go
+++ b/auth.go
@@ -14,7 +14,9 @@
 
 package errors
 
+import "net/http"
+
 // Unauthenticated returns an unauthenticated error
 func Unauthenticated(scheme string) Error {
-	return New(401, "unauthenticated for %s", scheme)
+	return New(http.StatusUnauthorized, "unauthenticated for %s", scheme)
 }


### PR DESCRIPTION
Replaces:
- `422` -> `http.StatusUnprocessableEntity`
- `head` -> `http.MethodHead`
- `401` -> `http.StatusUnauthorized`