### PR TITLE
Add ValidateName to CompositeError

### DIFF
--- a/headers.go
+++ b/headers.go
@@ -51,11 +51,16 @@ func (e Validation) MarshalJSON() ([]byte, error) {
 	})
 }
 
-// ValidateName produces an error message name for an aliased property
+// ValidateName sets the name for a validation or updates it for a nested property
 func (e *Validation) ValidateName(name string) *Validation {
-	if e.Name == "" && name != "" {
-		e.Name = name
-		e.message = name + e.message
+	if name != "" {
+		if e.Name == "" {
+			e.Name = name
+			e.message = name + e.message
+		} else {
+			e.Name = name + "." + e.Name
+			e.message = name + "." + e.message
+		}
 	}
 	return e
 }

--- a/schema.go
+++ b/schema.go
@@ -138,6 +138,17 @@ func CompositeValidationError(errors ...error) *CompositeError {
 	}
 }
 
+// ValidateName updates all Validation error message names for an aliased property
+func (c *CompositeError) ValidateName(name string) *CompositeError {
+	for _, e := range c.Errors {
+		if ve, ok := e.(*Validation); ok {
+			_ = ve.ValidateName(name)
+		}
+	}
+
+	return c
+}
+
 // FailedAllPatternProperties an error for when the property doesn't match a pattern
 func FailedAllPatternProperties(name, in, key string) *Validation {
 	msg := fmt.Sprintf(failedAllPatternProps, name, key, in)

--- a/schema.go
+++ b/schema.go
@@ -138,11 +138,13 @@ func CompositeValidationError(errors ...error) *CompositeError {
 	}
 }
 
-// ValidateName updates all Validation error message names for an aliased property
+// ValidateName recursively sets the name for all validations or updates them for nested properties
 func (c *CompositeError) ValidateName(name string) *CompositeError {
-	for _, e := range c.Errors {
+	for i, e := range c.Errors {
 		if ve, ok := e.(*Validation); ok {
-			_ = ve.ValidateName(name)
+			c.Errors[i] = ve.ValidateName(name)
+		} else if ce, ok := e.(*CompositeError); ok {
+			c.Errors[i] = ce.ValidateName(name)
 		}
 	}
 


### PR DESCRIPTION
Added a ValidateName method to CompositeError to mirror the same API in Validation type to enable generated validation logic to alias CompositeErrors the same wait it aliases Validations.

Fixes #31 