### PR TITLE
Fix ValidName tests

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -191,12 +191,13 @@ func TestValidateName(t *testing.T) {
 	assert.EqualValues(t, "myValidation", vv.Name)
 	assert.EqualValues(t, "myMessage", vv.message)
 
-	// unchanged
+	// forced
 	vv = v.ValidateName("myNewName")
-	assert.EqualValues(t, "myValidation", vv.Name)
-	assert.EqualValues(t, "myMessage", vv.message)
+	assert.EqualValues(t, "myNewName.myValidation", vv.Name)
+	assert.EqualValues(t, "myNewName.myMessage", vv.message)
 
 	v.Name = ""
+	v.message = "myMessage"
 
 	// unchanged
 	vv = v.ValidateName("")


### PR DESCRIPTION
This fixes the tests for the #32 PR, which did not update them to match the implementation changes.

Was updating the Debian packages for this module, and could not proceed due to the failing tests.