### PR TITLE
fix(ci): muted warnings in CI runs due to cache conflicts

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           version: latest
           only-new-issues: true
+          skip-cache: true
 
   test:
     name: Unit tests
@@ -38,7 +39,7 @@ jobs:
 
     - uses: actions/checkout@v3
 
-    - run: go test -v -race -coverprofile="coverage-${{ matrix.os }}.${{ matrix.go_version }}.out" -covermode=atomic ./...
+    - run: go test -v -race -coverprofile="coverage-${{ matrix.os }}.${{ matrix.go_version }}.out" -covermode=atomic -coverpkg=$(go list)/... ./...
 
     - name: Upload coverage to codecov
       uses: codecov/codecov-action@v3


### PR DESCRIPTION
Every time a job is posted, I receive false alarm failure notifications because of some cache conflict during the linting job.

Reference: https://github.com/golangci/golangci-lint-action/issues/807